### PR TITLE
fix: selector API

### DIFF
--- a/src/Api/Configuration.php
+++ b/src/Api/Configuration.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Str;
 class Configuration extends Client
 {
     /**
-     * [__call description]
-     * @param  string $name      [description]
-     * @param  array  $arguments [description]
-     * @return [type]            [description]
+     * Get Selector configuration
+     *
+     * @see https://developers.freshworks.com/crm/api/#admin_configuration
+     *
+     * @param string $name Selector name
      */
-    public function __call(string $name, array $arguments = []): Object
+    public function selector(string $name): object
     {
         return $this->go('GET', 'selector/' . Str::snake($name));
     }


### PR DESCRIPTION
The current method doesn't work because the client extends the guzzle client
`Declaration of CodeGreenCreative\Freshworks\Api\Configuration::__call(string $name, array $arguments = Array): object should be compatible with GuzzleHttp\Client::__call($method, $args)`

This changes the method name to make more sense, remove the params (endpoints take none)