### PR TITLE
fix: exception handling + wrap guzzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ composer.phar
 composer.lock
 vendor
 .DS_Store
+.phpunit.result.cache
+build

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,16 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "illuminate/support": "^6|^7|^8",
         "guzzlehttp/guzzle": "^6.3.1|^7.0.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0",
-        "phpunit/phpunit": "^8.5|^9.0"
+        "phpunit/phpunit": "^8.5|^9.0",
+        "nunomaduro/collision": "^5.3",
+        "orchestra/testbench": "^6.15",
+        "pestphp/pest": "^1.18",
+        "pestphp/pest-plugin-laravel": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -27,6 +30,10 @@
         "psr-4": {
             "CodeGreenCreative\\Freshworks\\Tests\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "./vendor/bin/pest --no-coverage",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnFailure="false"
+        executionOrder="random"
+        failOnWarning="true"
+        failOnRisky="true"
+        failOnEmptyTestSuite="true"
+        beStrictAboutOutputDuringTests="true"
+        verbose="true"
+>
+    <testsuites>
+        <testsuite name="Laravel Freshworks Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -37,12 +37,14 @@ class Client
 
     /**
      * Go perform the request
-     * @param  string $method
-     * @param  string $uri
-     * @param  array  $options
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $options
+     *
      * @return \CodeGreenCreative\Freshworks\Client
      */
-    public function go(string $method, $uri = '', array $options = []): Object
+    public function go(string $method, string $uri = '', array $options = []): object
     {
         try {
             $this->response = $this->client->request($method, $uri, $options);

--- a/src/Exceptions/FreshworksException.php
+++ b/src/Exceptions/FreshworksException.php
@@ -8,9 +8,9 @@ use GuzzleHttp\Psr7\Response;
 class FreshworksException extends \Exception
 {
     /** @var ?Response */
-    protected $response;
+    protected ?Response $response;
 
-    public static function fromGuzzleException(RequestException $requestException)
+    public static function fromGuzzleException(RequestException $requestException): self
     {
         $response = $requestException->getResponse();
 
@@ -18,7 +18,7 @@ class FreshworksException extends \Exception
             return new self($requestException->getMessage(), $requestException->getCode());
         }
 
-        $exception = new self((string) $response->getBody(), $response->getStatusCode());
+        $exception = new self(trim(sprintf("%s\n\%s", $requestException->getMessage(), (string) $response->getBody())), $response->getStatusCode());
         $exception->response = $response;
 
         return $exception;

--- a/src/Exceptions/FreshworksException.php
+++ b/src/Exceptions/FreshworksException.php
@@ -2,6 +2,30 @@
 
 namespace CodeGreenCreative\Freshworks\Exceptions;
 
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Response;
+
 class FreshworksException extends \Exception
 {
+    /** @var Response */
+    protected $response;
+
+    public static function fromGuzzleException(RequestException $requestException)
+    {
+        $response = $requestException->getResponse();
+
+        if (!$response) {
+            return new self($requestException->getMessage(), $requestException->getCode());
+        }
+
+        $exception = new self((string) $response->getBody(), $response->getStatusCode());
+        $exception->response = $response;
+
+        return $exception;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
 }

--- a/src/Exceptions/FreshworksException.php
+++ b/src/Exceptions/FreshworksException.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Psr7\Response;
 
 class FreshworksException extends \Exception
 {
-    /** @var Response */
+    /** @var ?Response */
     protected $response;
 
     public static function fromGuzzleException(RequestException $requestException)
@@ -24,7 +24,7 @@ class FreshworksException extends \Exception
         return $exception;
     }
 
-    public function getResponse(): Response
+    public function getResponse(): ?Response
     {
         return $this->response;
     }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+it('throws non guzzle exception as freshworks exception', function () {
+    \CodeGreenCreative\Freshworks\FreshworksFacade::contacts()->all(1);
+})->throws(\CodeGreenCreative\Freshworks\Exceptions\FreshworksException::class);
+
+it('throws guzzle exception as freshworks exception with 404 response', function () {
+    config()->set('freshworks.domain', 'testing');
+    \CodeGreenCreative\Freshworks\FreshworksFacade::contacts()->all(1);
+})->throws(\CodeGreenCreative\Freshworks\Exceptions\FreshworksException::class, 'Client error: `GET https://testing.myfreshworks.com/crm/sales/api/contacts/view/1` resulted in a `404 Not Found` response');
+
+it('throws guzzle exception as freshworks exception with 401 response', function () {
+    config()->set('freshworks.domain', 'edgility-au');
+    \CodeGreenCreative\Freshworks\FreshworksFacade::contacts()->all(1);
+})->throws(\CodeGreenCreative\Freshworks\Exceptions\FreshworksException::class, "Client error: `GET https://edgility-au.myfreshworks.com/crm/sales/api/contacts/view/1` resulted in a `401 Unauthorized` response:\n{\"login\":\"failed\",\"message\":null}");

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use CodeGreenCreative\Freshworks\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CodeGreenCreative\Freshworks\Tests;
+
+use CodeGreenCreative\Freshworks\FreshworksServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            FreshworksServiceProvider::class,
+        ];
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        config()->set('database.default', 'testing');
+    }
+}


### PR DESCRIPTION
This fixed a couple of bits. Firstly, it wraps the guzzle client instead of extending it, which it does not need to. This makes it so the internal api isn't exposed. Closes #5 

Secondly, the exception handling currently breaks if the thrown exception doesn't have a `getResponse()` method.

This corrects the handling to detect guzzle responses, throw the exception with the object, and handle normal other exceptions as well 

Closes #7 