### PR TITLE
chore(deps): bump illuminate/support for laravel 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "illuminate/support": "^6|^7|^8|^9",
+        "illuminate/support": "^6|^7|^8|^9|^10",
         "guzzlehttp/guzzle": "^7.4.4"
     },
     "require-dev": {


### PR DESCRIPTION
This is needed in order to keep using the package after upgrading to laravel 10.